### PR TITLE
Update settings to center window when changing resolution

### DIFF
--- a/scenes/autoload/SettingsHandler.gd
+++ b/scenes/autoload/SettingsHandler.gd
@@ -14,6 +14,17 @@ func _ready():
 ## Applies settings from SettingsDict
 func _apply_settings():
 	DisplayServer.window_set_size(Vector2(SettingsDict.resolution[0], SettingsDict.resolution[1]))
+	
+	# Center the window
+	var window_size = DisplayServer.window_get_size()
+	var screen_size = DisplayServer.screen_get_size()
+
+	var window_pos = Vector2.ZERO
+	window_pos.x = screen_size.x / 2 - window_size.x / 2
+	window_pos.y = screen_size.y / 2 - window_size.y / 2
+	
+	DisplayServer.window_set_position(window_pos)
+	
 	if SettingsDict.fullscreen:
 		DisplayServer.window_set_mode(DisplayServer.WindowMode.WINDOW_MODE_FULLSCREEN)
 	else:


### PR DESCRIPTION
Right now it leaves the center the same, so when I change it to 1080p, part of the window is off screen.
This update fixes it so the window will be centered on the screen.